### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/187/435/421187435.geojson
+++ b/data/421/187/435/421187435.geojson
@@ -304,6 +304,9 @@
     },
     "wof:country":"CW",
     "wof:created":1459009513,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"518b0eda8a981bc48435751560f63f0a",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
         }
     ],
     "wof:id":421187435,
-    "wof:lastmodified":1566709954,
+    "wof:lastmodified":1582379114,
     "wof:name":"Willemstad",
     "wof:parent_id":85670465,
     "wof:placetype":"locality",

--- a/data/856/324/41/85632441.geojson
+++ b/data/856/324/41/85632441.geojson
@@ -482,6 +482,10 @@
     ],
     "wof:country":"CW",
     "wof:country_alpha3":"CUW",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"6bc55b90f0c1cea2665fd470a151c5e3",
     "wof:hierarchy":[
         {
@@ -498,7 +502,7 @@
         "pap",
         "nld"
     ],
-    "wof:lastmodified":1566709951,
+    "wof:lastmodified":1582379114,
     "wof:name":"Curacao",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/857/940/41/85794041.geojson
+++ b/data/857/940/41/85794041.geojson
@@ -183,6 +183,10 @@
         "qs_pg:id":281689
     },
     "wof:country":"CW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4dea1a1c3be186adaffd9522a3b9df24",
     "wof:hierarchy":[
         {
@@ -197,7 +201,7 @@
     "wof:lang":[
         "dut"
     ],
-    "wof:lastmodified":1566709951,
+    "wof:lastmodified":1582379114,
     "wof:name":"Ararat",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/940/45/85794045.geojson
+++ b/data/857/940/45/85794045.geojson
@@ -68,6 +68,10 @@
         "qs_pg:id":228589
     },
     "wof:country":"CW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"9a6048581eaa9a7dce54a2d7a965e4a4",
     "wof:hierarchy":[
         {
@@ -82,7 +86,7 @@
     "wof:lang":[
         "dut"
     ],
-    "wof:lastmodified":1566709950,
+    "wof:lastmodified":1582379113,
     "wof:name":"Cher Asile",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/940/49/85794049.geojson
+++ b/data/857/940/49/85794049.geojson
@@ -243,6 +243,10 @@
         "wd:id":"Q202027"
     },
     "wof:country":"CW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4d6dc711c93f68a331f47e8e617d03bc",
     "wof:hierarchy":[
         {
@@ -257,7 +261,7 @@
     "wof:lang":[
         "dut"
     ],
-    "wof:lastmodified":1566709951,
+    "wof:lastmodified":1582379114,
     "wof:name":"Cornet",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/940/53/85794053.geojson
+++ b/data/857/940/53/85794053.geojson
@@ -67,6 +67,10 @@
         "qs_pg:id":211102
     },
     "wof:country":"CW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0c34a52cbfd060d13bf54447400c20fb",
     "wof:hierarchy":[
         {
@@ -81,7 +85,7 @@
     "wof:lang":[
         "dut"
     ],
-    "wof:lastmodified":1566709950,
+    "wof:lastmodified":1582379114,
     "wof:name":"Dominguito",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/940/55/85794055.geojson
+++ b/data/857/940/55/85794055.geojson
@@ -68,6 +68,10 @@
         "qs_pg:id":228592
     },
     "wof:country":"CW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"938d56ef6ba23c788efe4a1b7f90b5a3",
     "wof:hierarchy":[
         {
@@ -82,7 +86,7 @@
     "wof:lang":[
         "dut"
     ],
-    "wof:lastmodified":1566709950,
+    "wof:lastmodified":1582379114,
     "wof:name":"Paradijs",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/940/65/85794065.geojson
+++ b/data/857/940/65/85794065.geojson
@@ -68,6 +68,10 @@
         "qs_pg:id":1082313
     },
     "wof:country":"CW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bd4c68e0e0ce4ef25eba85c62b6a75e3",
     "wof:hierarchy":[
         {
@@ -82,7 +86,7 @@
     "wof:lang":[
         "dut"
     ],
-    "wof:lastmodified":1566709950,
+    "wof:lastmodified":1582379113,
     "wof:name":"Punda",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/940/69/85794069.geojson
+++ b/data/857/940/69/85794069.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":489297
     },
     "wof:country":"CW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"05eda13fef8f5c9c4b12b87eed097e59",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "dut"
     ],
-    "wof:lastmodified":1566709950,
+    "wof:lastmodified":1582379113,
     "wof:name":"St. Jago",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/940/73/85794073.geojson
+++ b/data/857/940/73/85794073.geojson
@@ -72,6 +72,10 @@
         "wd:id":"Q22666296"
     },
     "wof:country":"CW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"26996ae38a743fbbcf4377a520fecfe5",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "dut"
     ],
-    "wof:lastmodified":1566709950,
+    "wof:lastmodified":1582379113,
     "wof:name":"Steenrijk",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/940/79/85794079.geojson
+++ b/data/857/940/79/85794079.geojson
@@ -79,6 +79,10 @@
         "wd:id":"Q19903803"
     },
     "wof:country":"CW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"dd6231d4470b9d0e90ca9f21548227a4",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "dut"
     ],
-    "wof:lastmodified":1566709950,
+    "wof:lastmodified":1582379114,
     "wof:name":"Wishi",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.