### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/586/851/3/1125868513.geojson
+++ b/data/112/586/851/3/1125868513.geojson
@@ -34,10 +34,16 @@
     "name:eng_x_preferred":[
         "Barber"
     ],
+    "name:fra_x_preferred":[
+        "Barber"
+    ],
     "name:nld_x_preferred":[
         "Barber"
     ],
     "name:nob_x_preferred":[
+        "Barber"
+    ],
+    "name:pap_x_preferred":[
         "Barber"
     ],
     "name:pol_x_preferred":[
@@ -86,7 +92,7 @@
         }
     ],
     "wof:id":1125868513,
-    "wof:lastmodified":1566709955,
+    "wof:lastmodified":1690868595,
     "wof:name":"Barber",
     "wof:parent_id":85670465,
     "wof:placetype":"locality",

--- a/data/421/187/435/421187435.geojson
+++ b/data/421/187/435/421187435.geojson
@@ -31,6 +31,12 @@
     "name:ara_x_variant":[
         "\u0648\u064a\u0644\u0645\u0633\u062a\u0627\u062f"
     ],
+    "name:arg_x_preferred":[
+        "Willemstad"
+    ],
+    "name:arz_x_preferred":[
+        "\u0648\u064a\u0644\u0645\u0633\u062a\u0627\u062f"
+    ],
     "name:ast_x_preferred":[
         "Willemstad"
     ],
@@ -73,6 +79,9 @@
     "name:ell_x_preferred":[
         "\u0392\u03af\u03bb\u03bb\u03b5\u03bc\u03c3\u03c4\u03b1\u03bd\u03c4"
     ],
+    "name:ell_x_variant":[
+        "\u0392\u03af\u03bb\u03bb\u03b5\u03bc\u03c3\u03c4\u03b1\u03c4"
+    ],
     "name:eng_x_preferred":[
         "Willemstad"
     ],
@@ -99,6 +108,9 @@
     ],
     "name:fry_x_preferred":[
         "Willemst\u00ead"
+    ],
+    "name:gle_x_preferred":[
+        "Willemstad"
     ],
     "name:glg_x_preferred":[
         "Willemstad"
@@ -127,6 +139,9 @@
     "name:ind_x_preferred":[
         "Willemstad"
     ],
+    "name:isl_x_preferred":[
+        "Willemstad"
+    ],
     "name:ita_x_preferred":[
         "Willemstad"
     ],
@@ -139,6 +154,9 @@
     "name:kat_x_preferred":[
         "\u10d5\u10d8\u10da\u10d4\u10db\u10e1\u10e2\u10d0\u10d3\u10d8"
     ],
+    "name:kaz_x_preferred":[
+        "\u0412\u0438\u043b\u043b\u0435\u043c\u0441\u0442\u0430\u0434"
+    ],
     "name:kir_x_preferred":[
         "\u0412\u0438\u043b\u043b\u0435\u043c\u0441\u0442\u0430\u0434"
     ],
@@ -147,6 +165,9 @@
     ],
     "name:lad_x_preferred":[
         "Willemstad"
+    ],
+    "name:lat_x_preferred":[
+        "Gulielmopolis"
     ],
     "name:lav_x_preferred":[
         "Villemstade"
@@ -159,6 +180,9 @@
     ],
     "name:mar_x_preferred":[
         "\u0935\u093f\u0932\u0947\u092e\u0936\u094d\u091f\u093e\u0921"
+    ],
+    "name:mkd_x_preferred":[
+        "\u0412\u0438\u043b\u0435\u043c\u0441\u0442\u0430\u0434"
     ],
     "name:msa_x_preferred":[
         "Willemstad"
@@ -217,6 +241,9 @@
     "name:spa_x_preferred":[
         "Willemstad"
     ],
+    "name:srd_x_preferred":[
+        "Willemstad"
+    ],
     "name:srp_x_preferred":[
         "\u0412\u0438\u043b\u0435\u043c\u0441\u0442\u0430\u0434"
     ],
@@ -244,11 +271,17 @@
     "name:uzb_x_preferred":[
         "Villemstad"
     ],
+    "name:vec_x_preferred":[
+        "Willemstad"
+    ],
     "name:vie_x_preferred":[
         "Willemstad"
     ],
     "name:war_x_preferred":[
         "Willemstad"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5a01\u5ec9\u65af\u5854\u5fb7"
     ],
     "name:yor_x_preferred":[
         "Willemstad"
@@ -319,7 +352,7 @@
         }
     ],
     "wof:id":421187435,
-    "wof:lastmodified":1607390883,
+    "wof:lastmodified":1690868595,
     "wof:name":"Willemstad",
     "wof:parent_id":85670465,
     "wof:placetype":"locality",

--- a/data/421/202/851/421202851.geojson
+++ b/data/421/202/851/421202851.geojson
@@ -43,6 +43,9 @@
     "name:deu_x_preferred":[
         "Nieuw Nederland"
     ],
+    "name:ell_x_preferred":[
+        "\u039d\u03ad\u03b1 \u039f\u03bb\u03bb\u03b1\u03bd\u03b4\u03af\u03b1"
+    ],
     "name:eng_x_preferred":[
         "New Netherland"
     ],
@@ -51,6 +54,9 @@
     ],
     "name:est_x_preferred":[
         "Uus-Holland"
+    ],
+    "name:eus_x_preferred":[
+        "Herbeherea Berria"
     ],
     "name:fas_x_preferred":[
         "\u0647\u0644\u0646\u062f \u0646\u0648"
@@ -76,6 +82,9 @@
     "name:hrv_x_preferred":[
         "Nova Nizozemska"
     ],
+    "name:hun_x_preferred":[
+        "\u00daj-Hollandia"
+    ],
     "name:ido_x_preferred":[
         "Nova-Nederlando"
     ],
@@ -93,6 +102,9 @@
     ],
     "name:kor_x_preferred":[
         "\ub274\ub124\ub35c\ub780\ub4dc"
+    ],
+    "name:kor_x_variant":[
+        "\ub2c8\uc6b0\ub124\ub370\ub97c\ub780\ud2b8"
     ],
     "name:lat_x_preferred":[
         "Nova Nederlandia"
@@ -148,6 +160,9 @@
     "name:ukr_x_preferred":[
         "\u041d\u043e\u0432\u0456 \u041d\u0456\u0434\u0435\u0440\u043b\u0430\u043d\u0434\u0438"
     ],
+    "name:vec_x_preferred":[
+        "Novi Paezi Basi"
+    ],
     "name:vie_x_preferred":[
         "T\u00e2n H\u00e0 Lan"
     ],
@@ -199,7 +214,7 @@
         }
     ],
     "wof:id":421202851,
-    "wof:lastmodified":1566709954,
+    "wof:lastmodified":1690868594,
     "wof:name":"Nieuw Nederland",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/856/324/41/85632441.geojson
+++ b/data/856/324/41/85632441.geojson
@@ -37,6 +37,9 @@
     "name:arg_x_preferred":[
         "Cura\u00e7ao"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0648\u0631\u0627\u0633\u0627\u0648"
+    ],
     "name:ast_x_preferred":[
         "Cura\u00e7ao"
     ],
@@ -57,6 +60,9 @@
     ],
     "name:ben_x_preferred":[
         "\u0995\u09bf\u0989\u09b0\u09be\u09b8\u09be\u0993"
+    ],
+    "name:ben_x_variant":[
+        "\u0995\u09c1\u09b0\u09be\u0995\u09be\u0993"
     ],
     "name:bos_x_preferred":[
         "Cura\u00e7ao"
@@ -79,7 +85,13 @@
     "name:ces_x_preferred":[
         "Cura\u00e7ao"
     ],
+    "name:chr_x_preferred":[
+        "\u13ab\u13b3\u13a8\u13a3"
+    ],
     "name:chy_x_preferred":[
+        "Cura\u00e7ao"
+    ],
+    "name:cos_x_preferred":[
         "Cura\u00e7ao"
     ],
     "name:cym_x_preferred":[
@@ -138,6 +150,9 @@
     "name:gcr_x_preferred":[
         "Cura\u00e7ao"
     ],
+    "name:gle_x_preferred":[
+        "Cura\u00e7ao"
+    ],
     "name:glg_x_preferred":[
         "Cura\u00e7ao"
     ],
@@ -152,6 +167,12 @@
     ],
     "name:hak_x_preferred":[
         "Cura\u00e7ao"
+    ],
+    "name:hat_x_preferred":[
+        "Kiraso"
+    ],
+    "name:hau_x_preferred":[
+        "Curacao"
     ],
     "name:heb_x_preferred":[
         "\u05e7\u05d5\u05e8\u05d0\u05e1\u05d0\u05d5"
@@ -170,6 +191,9 @@
     ],
     "name:hye_x_preferred":[
         "\u053f\u0575\u0578\u0582\u0580\u0561\u057d\u0561\u0578"
+    ],
+    "name:ido_x_preferred":[
+        "Kuracao"
     ],
     "name:ilo_x_preferred":[
         "Cura\u00e7ao"
@@ -207,6 +231,15 @@
     "name:kbd_x_preferred":[
         "\u041a\u044e\u0440\u0430\u0441\u0430\u0443\u044d"
     ],
+    "name:kcg_x_preferred":[
+        "Kura\u0331sa\u0331u"
+    ],
+    "name:khm_x_preferred":[
+        "\u1782\u17bc\u179a\u17c9\u17b6\u179f\u17c5"
+    ],
+    "name:kir_x_preferred":[
+        "\u041a\u04af\u0440\u0430\u0441\u0430\u0443"
+    ],
     "name:kor_x_preferred":[
         "\ud034\ub77c\uc18c"
     ],
@@ -215,6 +248,9 @@
     ],
     "name:lat_x_preferred":[
         "Insula Curacensis"
+    ],
+    "name:lat_x_variant":[
+        "Curacium"
     ],
     "name:lav_x_preferred":[
         "Kirasao"
@@ -227,6 +263,9 @@
     ],
     "name:lit_x_preferred":[
         "Kiurasao"
+    ],
+    "name:lld_x_preferred":[
+        "Cura\u00e7ao"
     ],
     "name:lmo_x_preferred":[
         "Cura\u00e7ao"
@@ -300,6 +339,9 @@
     "name:por_x_preferred":[
         "Cura\u00e7ao"
     ],
+    "name:por_x_variant":[
+        "Cura\u00e7au"
+    ],
     "name:ron_x_preferred":[
         "Cura\u00e7ao"
     ],
@@ -312,10 +354,16 @@
     "name:sco_x_preferred":[
         "Cura\u00e7ao"
     ],
+    "name:shn_x_preferred":[
+        "\u1075\u1030\u1038\u101b\u1083\u1087\u101e\u1062\u101d\u103a\u1087"
+    ],
     "name:sin_x_preferred":[
         "\u0d9a\u0dd4\u0dbb\u0dcf\u0d9a\u0dcf\u0d95"
     ],
     "name:slk_x_preferred":[
+        "Cura\u00e7ao"
+    ],
+    "name:slv_x_preferred":[
         "Cura\u00e7ao"
     ],
     "name:spa_x_preferred":[
@@ -324,11 +372,17 @@
     "name:spa_x_variant":[
         "Pa\u00eds de Curazao"
     ],
+    "name:srd_x_preferred":[
+        "Cura\u00e7ao"
+    ],
     "name:srn_x_preferred":[
         "Korsow"
     ],
     "name:srp_x_preferred":[
         "\u041a\u0443\u0440\u0430\u0441\u0430\u043e"
+    ],
+    "name:stq_x_preferred":[
+        "Cura\u00e7ao"
     ],
     "name:sun_x_preferred":[
         "Kuraso"
@@ -354,8 +408,14 @@
     "name:tha_x_preferred":[
         "\u0e01\u0e37\u0e2d\u0e23\u0e32\u0e40\u0e0b\u0e32"
     ],
+    "name:ton_x_preferred":[
+        "Kulasao"
+    ],
     "name:tur_x_preferred":[
         "Cura\u00e7ao"
+    ],
+    "name:uig_x_preferred":[
+        "\u0643\u06c7\u0631\u0627\u0633\u0648 \u0626\u0627\u0631\u0649\u0644\u0649"
     ],
     "name:ukr_x_preferred":[
         "\u041a\u044e\u0440\u0430\u0441\u0430\u043e"
@@ -365,6 +425,9 @@
     ],
     "name:uzb_x_preferred":[
         "Kyurasao"
+    ],
+    "name:vec_x_preferred":[
+        "Cura\u00e7ao"
     ],
     "name:vie_x_preferred":[
         "Cura\u00e7ao"
@@ -383,6 +446,9 @@
     ],
     "name:yue_x_preferred":[
         "\u5eab\u62c9\u7d22\u5cf6"
+    ],
+    "name:yue_x_variant":[
+        "\u53e4\u62c9\u7d22\u5cf6"
     ],
     "name:zea_x_preferred":[
         "Cura\u00e7ao"
@@ -577,7 +643,7 @@
         "pap",
         "nld"
     ],
-    "wof:lastmodified":1617827636,
+    "wof:lastmodified":1690868594,
     "wof:name":"Curacao",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/857/940/49/85794049.geojson
+++ b/data/857/940/49/85794049.geojson
@@ -66,6 +66,9 @@
     "name:epo_x_preferred":[
         "Korneto"
     ],
+    "name:epo_x_variant":[
+        "korneto"
+    ],
     "name:est_x_preferred":[
         "Kornet"
     ],
@@ -87,11 +90,20 @@
     "name:fry_x_preferred":[
         "Kornet"
     ],
+    "name:fry_x_variant":[
+        "kornet"
+    ],
     "name:gle_x_preferred":[
         "Coirn\u00e9ad"
     ],
+    "name:gle_x_variant":[
+        "coirn\u00e9ad"
+    ],
     "name:glg_x_preferred":[
         "Corneta"
+    ],
+    "name:glg_x_variant":[
+        "corneta"
     ],
     "name:gsw_x_preferred":[
         "Kornett"
@@ -105,14 +117,23 @@
     "name:hrv_x_preferred":[
         "Kornet"
     ],
+    "name:hrv_x_variant":[
+        "kornet"
+    ],
     "name:hun_x_preferred":[
         "Kornett"
+    ],
+    "name:hun_x_variant":[
+        "kornett"
     ],
     "name:hye_x_preferred":[
         "\u053f\u0578\u057c\u0576\u0565\u057f"
     ],
     "name:isl_x_preferred":[
         "Kornett"
+    ],
+    "name:isl_x_variant":[
+        "kornett"
     ],
     "name:ita_x_preferred":[
         "Cornetta"
@@ -126,11 +147,17 @@
     "name:kir_x_preferred":[
         "\u041a\u043e\u0440\u043d\u0435\u0442"
     ],
+    "name:kir_x_variant":[
+        "\u043a\u043e\u0440\u043d\u0435\u0442"
+    ],
     "name:kor_x_preferred":[
         "\ucf54\ub137"
     ],
     "name:lit_x_preferred":[
         "Kornetas"
+    ],
+    "name:lit_x_variant":[
+        "kornetas"
     ],
     "name:mya_x_preferred":[
         "\u1000\u1031\u102c\u1014\u1000\u103a"
@@ -139,7 +166,8 @@
         "Kornet"
     ],
     "name:nld_x_variant":[
-        "Cornet"
+        "Cornet",
+        "kornet"
     ],
     "name:nno_x_preferred":[
         "Kornett"
@@ -156,6 +184,9 @@
     "name:oci_x_preferred":[
         "Cornet"
     ],
+    "name:oci_x_variant":[
+        "cornet"
+    ],
     "name:pol_x_preferred":[
         "Kornet"
     ],
@@ -170,6 +201,9 @@
     ],
     "name:ron_x_preferred":[
         "Cornet"
+    ],
+    "name:ron_x_variant":[
+        "cornet"
     ],
     "name:rus_x_preferred":[
         "\u041a\u043e\u0440\u043d\u0435\u0442"
@@ -198,11 +232,20 @@
     "name:tur_x_preferred":[
         "Kornet"
     ],
+    "name:tur_x_variant":[
+        "kornet"
+    ],
     "name:ukr_x_preferred":[
         "\u041a\u043e\u0440\u043d\u0435\u0442"
     ],
+    "name:ukr_x_variant":[
+        "\u043a\u043e\u0440\u043d\u0435\u0442"
+    ],
     "name:uzb_x_preferred":[
         "Kornet"
+    ],
+    "name:uzb_x_variant":[
+        "kornet"
     ],
     "name:zho_x_preferred":[
         "\u77ed\u865f"
@@ -261,7 +304,7 @@
     "wof:lang":[
         "dut"
     ],
-    "wof:lastmodified":1582379114,
+    "wof:lastmodified":1690868594,
     "wof:name":"Cornet",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/415/313/890415313.geojson
+++ b/data/890/415/313/890415313.geojson
@@ -31,6 +31,9 @@
     "name:arg_x_preferred":[
         "Cura\u00e7ao"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0648\u0631\u0627\u0633\u0627\u0648"
+    ],
     "name:ast_x_preferred":[
         "Cura\u00e7ao"
     ],
@@ -51,6 +54,9 @@
     ],
     "name:ben_x_preferred":[
         "\u0995\u09bf\u0989\u09b0\u09be\u09b8\u09be\u0993"
+    ],
+    "name:ben_x_variant":[
+        "\u0995\u09c1\u09b0\u09be\u0995\u09be\u0993"
     ],
     "name:bos_x_preferred":[
         "Cura\u00e7ao"
@@ -73,7 +79,13 @@
     "name:ces_x_preferred":[
         "Cura\u00e7ao"
     ],
+    "name:chr_x_preferred":[
+        "\u13ab\u13b3\u13a8\u13a3"
+    ],
     "name:chy_x_preferred":[
+        "Cura\u00e7ao"
+    ],
+    "name:cos_x_preferred":[
         "Cura\u00e7ao"
     ],
     "name:cym_x_preferred":[
@@ -124,6 +136,12 @@
     "name:gag_x_preferred":[
         "Cura\u00e7ao"
     ],
+    "name:gcr_x_preferred":[
+        "Cura\u00e7ao"
+    ],
+    "name:gle_x_preferred":[
+        "Cura\u00e7ao"
+    ],
     "name:glg_x_preferred":[
         "Cura\u00e7ao"
     ],
@@ -138,6 +156,12 @@
     ],
     "name:hak_x_preferred":[
         "Cura\u00e7ao"
+    ],
+    "name:hat_x_preferred":[
+        "Kiraso"
+    ],
+    "name:hau_x_preferred":[
+        "Curacao"
     ],
     "name:heb_x_preferred":[
         "\u05e7\u05d5\u05e8\u05d0\u05e1\u05d0\u05d5"
@@ -157,6 +181,9 @@
     "name:hye_x_preferred":[
         "\u053f\u0575\u0578\u0582\u0580\u0561\u057d\u0561\u0578"
     ],
+    "name:ido_x_preferred":[
+        "Kuracao"
+    ],
     "name:ilo_x_preferred":[
         "Cura\u00e7ao"
     ],
@@ -175,6 +202,9 @@
     "name:jpn_x_preferred":[
         "\u30ad\u30e5\u30e9\u30bd\u30fc\u5cf6"
     ],
+    "name:jpn_x_variant":[
+        "\u30ad\u30e5\u30e9\u30bd\u30fc"
+    ],
     "name:kan_x_preferred":[
         "\u0c95\u0cc1\u0cb0\u0cbe\u0c95\u0cca\u0cb5\u0cca"
     ],
@@ -187,6 +217,15 @@
     "name:kbd_x_preferred":[
         "\u041a\u044e\u0440\u0430\u0441\u0430\u0443\u044d"
     ],
+    "name:kcg_x_preferred":[
+        "Kura\u0331sa\u0331u"
+    ],
+    "name:khm_x_preferred":[
+        "\u1782\u17bc\u179a\u17c9\u17b6\u179f\u17c5"
+    ],
+    "name:kir_x_preferred":[
+        "\u041a\u04af\u0440\u0430\u0441\u0430\u0443"
+    ],
     "name:kor_x_preferred":[
         "\ud034\ub77c\uc18c"
     ],
@@ -195,6 +234,9 @@
     ],
     "name:lat_x_preferred":[
         "Insula Curacensis"
+    ],
+    "name:lat_x_variant":[
+        "Curacium"
     ],
     "name:lav_x_preferred":[
         "Kirasao"
@@ -207,6 +249,9 @@
     ],
     "name:lit_x_preferred":[
         "Kiurasao"
+    ],
+    "name:lld_x_preferred":[
+        "Cura\u00e7ao"
     ],
     "name:lmo_x_preferred":[
         "Cura\u00e7ao"
@@ -274,6 +319,9 @@
     "name:por_x_preferred":[
         "Cura\u00e7ao"
     ],
+    "name:por_x_variant":[
+        "Cura\u00e7au"
+    ],
     "name:ron_x_preferred":[
         "Cura\u00e7ao"
     ],
@@ -286,20 +334,32 @@
     "name:sco_x_preferred":[
         "Cura\u00e7ao"
     ],
+    "name:shn_x_preferred":[
+        "\u1075\u1030\u1038\u101b\u1083\u1087\u101e\u1062\u101d\u103a\u1087"
+    ],
     "name:sin_x_preferred":[
         "\u0d9a\u0dd4\u0dbb\u0dcf\u0d9a\u0dcf\u0d95"
     ],
     "name:slk_x_preferred":[
         "Cura\u00e7ao"
     ],
+    "name:slv_x_preferred":[
+        "Cura\u00e7ao"
+    ],
     "name:spa_x_preferred":[
         "Curazao"
+    ],
+    "name:srd_x_preferred":[
+        "Cura\u00e7ao"
     ],
     "name:srn_x_preferred":[
         "Korsow"
     ],
     "name:srp_x_preferred":[
         "\u041a\u0443\u0440\u0430\u0441\u0430\u043e"
+    ],
+    "name:stq_x_preferred":[
+        "Cura\u00e7ao"
     ],
     "name:sun_x_preferred":[
         "Kuraso"
@@ -325,8 +385,14 @@
     "name:tha_x_preferred":[
         "\u0e01\u0e37\u0e2d\u0e23\u0e32\u0e40\u0e0b\u0e32"
     ],
+    "name:ton_x_preferred":[
+        "Kulasao"
+    ],
     "name:tur_x_preferred":[
         "Cura\u00e7ao"
+    ],
+    "name:uig_x_preferred":[
+        "\u0643\u06c7\u0631\u0627\u0633\u0648 \u0626\u0627\u0631\u0649\u0644\u0649"
     ],
     "name:ukr_x_preferred":[
         "\u041a\u044e\u0440\u0430\u0441\u0430\u043e"
@@ -337,17 +403,29 @@
     "name:uzb_x_preferred":[
         "Kyurasao"
     ],
+    "name:vec_x_preferred":[
+        "Cura\u00e7ao"
+    ],
     "name:vie_x_preferred":[
         "Cura\u00e7ao"
     ],
     "name:war_x_preferred":[
         "Cura\u00e7ao"
     ],
+    "name:wuu_x_preferred":[
+        "\u5e93\u62c9\u7d22"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10d9\u10d8\u10e3\u10e0\u10d0\u10e1\u10d0\u10dd"
+    ],
     "name:yor_x_preferred":[
         "Cura\u00e7ao"
     ],
     "name:yue_x_preferred":[
         "\u5eab\u62c9\u7d22\u5cf6"
+    ],
+    "name:yue_x_variant":[
+        "\u53e4\u62c9\u7d22\u5cf6"
     ],
     "name:zea_x_preferred":[
         "Cura\u00e7ao"
@@ -386,7 +464,7 @@
         }
     ],
     "wof:id":890415313,
-    "wof:lastmodified":1566709955,
+    "wof:lastmodified":1690868595,
     "wof:name":"Cura\u00e7ao",
     "wof:parent_id":85670465,
     "wof:placetype":"locality",

--- a/data/890/434/821/890434821.geojson
+++ b/data/890/434/821/890434821.geojson
@@ -19,7 +19,13 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:deu_x_preferred":[
+        "Westpunt"
+    ],
     "name:eng_x_preferred":[
+        "Westpunt"
+    ],
+    "name:ita_x_preferred":[
         "Westpunt"
     ],
     "name:nld_x_preferred":[
@@ -33,6 +39,9 @@
     ],
     "name:swe_x_preferred":[
         "Westpunt"
+    ],
+    "name:zho_x_preferred":[
+        "\u97e6\u65af\u7279\u84ec\u7279"
     ],
     "qs:name":"Sabana Westpunt",
     "qs:photos_9r":0,
@@ -63,7 +72,7 @@
         }
     ],
     "wof:id":890434821,
-    "wof:lastmodified":1566709955,
+    "wof:lastmodified":1690868595,
     "wof:name":"Sabana Westpunt",
     "wof:parent_id":85670465,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.