### PR TITLE
cw concordances, placetype local, and more

### DIFF
--- a/data/856/324/41/85632441.geojson
+++ b/data/856/324/41/85632441.geojson
@@ -616,12 +616,14 @@
         "gn:id":7626836,
         "gp:id":56558057,
         "hasc:id":"CW",
+        "iso:code":"CW",
         "m49:code":"531",
         "ne:adm0_a3":"CUW",
         "ne:id":1159321099,
         "qs_pg:id":694142,
         "wd:id":"Q25279"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         85670465
     ],
@@ -647,7 +649,7 @@
         "pap",
         "nld"
     ],
-    "wof:lastmodified":1694639561,
+    "wof:lastmodified":1695881220,
     "wof:name":"Curacao",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/704/65/85670465.geojson
+++ b/data/856/704/65/85670465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03848,
-    "geom:area_square_m":465076803.848612,
+    "geom:area_square_m":465076803.848549,
     "geom:bbox":"-69.1717423167,12.0413272164,-68.7397354809,12.3915062527",
     "geom:latitude":12.193821,
     "geom:longitude":-68.971306,
@@ -203,13 +203,15 @@
         "fips:code":"",
         "gn:id":-99,
         "gp:id":24549810,
-        "hasc:id":"CW.CU"
+        "hasc:id":"CW.CU",
+        "iso:code_pseudo":"CW"
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:coterminous":[
         85632441
     ],
     "wof:country":"CW",
-    "wof:geomhash":"72922b7f1982c0d793e018087c27e14f",
+    "wof:geomhash":"c379dbc23ce38004c5f03d971a90f541",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -226,7 +228,7 @@
         "pap",
         "nld"
     ],
-    "wof:lastmodified":1566709951,
+    "wof:lastmodified":1695884329,
     "wof:name":"Curacao",
     "wof:parent_id":85632441,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.